### PR TITLE
Fix assingments redirect and removed console.log

### DIFF
--- a/src/routes/course/[id]/+page.server.ts
+++ b/src/routes/course/[id]/+page.server.ts
@@ -4,16 +4,10 @@ import { redirect } from "@sveltejs/kit";
 
 export const load: PageServerLoad = async ({ cookies, params }) => {
 	const userId: number = Number(cookies.get("user"));
-
 	if (!userId) {
 		redirect(303, "/");
 	}
-
 	const course = await GetCourseFromId(Number(params.id), true);
-
-	console.log(course);
-
 	const user = await GetUserFromId(userId, true);
-
 	return { course, user };
 };

--- a/src/routes/course/[id]/+page.svelte
+++ b/src/routes/course/[id]/+page.svelte
@@ -59,7 +59,7 @@
 					<div class="space-y-3">
 						{#each assignments as assignment (assignment.Id)}
 							<a
-								href={resolve(`/course/${data.course?.Id}/assignment/${assignment.Id}`)}
+								href={resolve(`/assignments/${assignment.Id}`)}
 								class="block rounded-xl border border-gray-700 bg-gray-800 p-4 transition hover:border-gray-500 hover:bg-gray-700"
 							>
 								<div class="flex items-center justify-between gap-4">


### PR DESCRIPTION
This pull request makes minor improvements to the course page's server and client code. It removes unnecessary code and updates assignment links for better routing consistency.

Routing and code cleanup:

* Updated assignment links in `+page.svelte` to use the new `/assignments/[id]` route instead of the previous nested course path. ([src/routes/course/[id]/+page.svelteL62-R62](diffhunk://#diff-5827b09518eecc428ec5b52c6b7c5b8cc1bb6d6365ffae8f5c79e3eb5f797071 L62-R62))
* Removed unused `console.log` statements and streamlined the `load` function in `+page.server.ts` for clarity and cleanliness. ([src/routes/course/[id]/+page.server.tsL7-L17](diffhunk://#diff-00894a9fc587cf67fd3451dab252d65d87fcfafab663dac0d106f28456678f7e L7-L17))